### PR TITLE
No need to surround searches with quotes anymore.

### DIFF
--- a/helperRecip/Helpers.py
+++ b/helperRecip/Helpers.py
@@ -934,7 +934,6 @@ class Helpers(unittest.TestCase):
     def searchFor(self, search_term):
         self.util.waitForElementToBePresent(self.element.search_inputfield)
         self.assertTrue(self.util.isElementPresent(self.element.search_inputfield), "no search input field")
-        search_term = '"' + search_term +'"' 
         self.util.inputTextIntoFieldAndPressEnter(search_term, self.element.search_inputfield)
         
     def scheduleMeeting(self,title, date, start_time, end_time):


### PR DESCRIPTION
Due to [PR 1134 on ggrc-core](https://github.com/reciprocity/ggrc-core/pull/1134), it's no longer necessary, and in fact detrimental, to put quotes around search terms, and this reconciles the tests with the new app behavior.

Will break tests against grc-test until PR 1134 is carried over.
