### PR TITLE
Update active section selector for ggrc-core commit e7eadac2.

### DIFF
--- a/helperRecip/Elements.py
+++ b/helperRecip/Elements.py
@@ -195,7 +195,7 @@ class Elements(object):
         section_widget_join_object_link = '//section[contains(@id,"widget")]//a[contains(@data-join-option-type,"OBJECT")]'
         section_widget_expanded_join_link1 = '//section[contains(@id,"OBJECT_widget")]//a[@class="section-add"]'
         section_widget_expanded_join_link2 = '//section[contains(@id,"widget")]//span[contains(@class,"section-expander")]//a[contains(@data-join-option-type,"OBJECT")]'
-        section_active = '//section[contains(@id,"SECTION")][contains(@class,"active")]'
+        section_active = '//div[contains(@class, "object-nav")]//ul[contains(@class, "inner_nav")]/li[contains(@class, "active")]/a[contains(@href, "SECTION")]'
         section_add_link = '//a[@class="section-add"]'
         section_create_link = '//a[@class="section-create"]'
         sections_area_first_section = '//li[@data-object-type="section"][1]//div[@class="tree-title-area"]/span'


### PR DESCRIPTION
An `li` tag instead of a `section` tag gets labeled as active due to [this commit](https://github.com/reciprocity/ggrc-core/commit/e7eadac2) in ggrc-core, requiring an update of the `section_active` selector that the test uses to determine whether the right section has been set to active.

Note: to see the state of the page that led us to replace the selector, insert a break point at line 727 in helperRecip/Helpers.py.
