### PR TITLE
Workaround for quick-search bug.

### DIFF
--- a/helperRecip/Elements.py
+++ b/helperRecip/Elements.py
@@ -112,6 +112,7 @@ class Elements(object):
         left_nav_expand_object_section_link = '//ul[@class="top-level"]//li[contains(@data-model-name,"OBJECT")]/a'
         left_nav_expand_status = left_nav_expand_object_section_link + '[contains(@class, "active")]'
         left_nav_expand_object_section_link_one_result_after_search = '//ul[@class="top-level"]//li[contains(@data-model-name,"OBJECT")]/a//span[@class="item-count"][not(contains(.,"(0)"))]'
+        left_nav_sections_loaded = '//ul[@class="top-level"]//li[contains(@data-model-name,"Control")]/a//span[@class="item-count"][not(contains(.,"()"))]'  # for confirming that LHN itmes are loaded -- have a value the parens
         left_nav_object_section_add_button = '//ul[@class="top-level"]//li[contains(@data-model-name,"OBJECT")]//li[@class="add-new"]/a'
         left_nav_last_created_object_link = '//ul[@class="top-level"]//li[contains(@data-model-name,"SECTION")]//li[contains(.,"OBJECT_TITLE")]/a'
         left_nav_first_object_link_in_the_section = '//ul[@class="top-level"]//li[contains(@data-model-name,"SECTION")]/div/ul[contains(@class, "sub-level")]/li[@data-model="true"]/a[contains(@class, "show-extended")]'

--- a/helperRecip/Helpers.py
+++ b/helperRecip/Helpers.py
@@ -278,6 +278,7 @@ class Helpers(unittest.TestCase):
     @log_time
     def verifyObjectIsCreatedinLHNViaSearch(self, search_term, section):
         object_left_nav_section_object_link_with_one_result = self.element.left_nav_expand_object_section_link_one_result_after_search.replace("OBJECT", section)
+        self.util.waitForElementToBePresent(self.element.left_nav_sections_loaded)  # due to quick-lookup bug
         self.searchFor(search_term)
         self.util.waitForElementToBePresent(object_left_nav_section_object_link_with_one_result)
         self.assertTrue(self.util.isElementPresent(object_left_nav_section_object_link_with_one_result), "the search did not return one result as it's supposed to" )
@@ -374,6 +375,8 @@ class Helpers(unittest.TestCase):
     @log_time
     def showObjectLinkWithSearch(self, search_term, section):
         object_left_nav_section_object_link_with_one_result = self.element.left_nav_expand_object_section_link_one_result_after_search.replace("OBJECT", section)
+        self.util.waitForElementToBePresent(self.element.left_nav_sections_loaded)  # due to quick-lookup bug
+        time.sleep(5)  # extra delay for margin of error
         self.searchFor(search_term)
         self.util.waitForElementToBePresent(object_left_nav_section_object_link_with_one_result)
         self.assertTrue(self.util.isElementPresent(object_left_nav_section_object_link_with_one_result), "the search did not return one result as it's supposed to" )


### PR DESCRIPTION
Search was failing when done before LHN loads.  Written up as [bug 69799008](https://www.pivotaltracker.com/story/show/69799008); for now, this avoids the problem by waiting for an indication that the LHN is done loading.
