### PR TITLE
Give audits timestamp and refactor selector.

### DIFF
--- a/Audit/TestProgramAudit.py
+++ b/Audit/TestProgramAudit.py
@@ -71,7 +71,7 @@ class TestProgramAudit(WebDriverTestCase):
         new_audit_title = do.createAudit(program_name)
         
         # 5.  Confirm the audit appear in the widget
-        newly_created_audit = element.audit_area_created_audit.replace("AUDIT_TITLE", new_audit_title)
+        newly_created_audit = element.audit_area_by_title.replace("AUDIT_TITLE", new_audit_title)
         print newly_created_audit
         util.waitForElementToBePresent(newly_created_audit)
         self.assertTrue(util.isElementPresent(newly_created_audit), "do not see the newly created audit " +new_audit_title )
@@ -80,7 +80,7 @@ class TestProgramAudit(WebDriverTestCase):
         # GAPI could pop up here
         do.authorizeGAPI()
         util.scrollIntoView(newly_created_audit)
-        util.clickOn(newly_created_audit)
+        util.clickOn(newly_created_audit + element.first_link_within)
         #util.switch_to_active_element()
         util.max_screen()
         util.scrollIntoView(newly_created_audit)
@@ -244,12 +244,12 @@ class TestProgramAudit(WebDriverTestCase):
         ##util.backBrowser()
         ##util.refreshPage()
         ###waiting to audit to appear back
-        ##newly_created_audit = element.audit_area_created_audit.replace("AUDIT_TITLE", new_audit_title)
+        ##newly_created_audit = element.audit_area_by_title.replace("AUDIT_TITLE", new_audit_title)
         ##print newly_created_audit
         ##util.waitForElementToBePresent(newly_created_audit)
         ##self.assertTrue(util.isElementPresent(newly_created_audit), "do not see the newly created audit " +new_audit_title )
         ## 
-        ##newly_created_audit_open_link  = element.audit_area_created_audit_open_link.replace("AUDIT_TITLE", new_audit_title)
+        ##newly_created_audit_open_link  = element.audit_area_by_title.replace("AUDIT_TITLE", new_audit_title)
         ##print newly_created_audit_open_link
         ##util.waitForElementToBePresent(newly_created_audit_open_link)
         ##self.assertTrue(util.isElementPresent(newly_created_audit_open_link), "do not see the newly created audit open link "  )

--- a/Audit/TestProgramAuditCreate.py
+++ b/Audit/TestProgramAuditCreate.py
@@ -70,13 +70,13 @@ class TestProgramAuditCreate(WebDriverTestCase):
         new_audit_title = do.createAudit(program_name)
         
         # 5.  Confirm the audit appear in the widget
-        newly_created_audit = element.audit_area_created_audit.replace("AUDIT_TITLE", new_audit_title)
+        newly_created_audit = element.audit_area_by_title.replace("AUDIT_TITLE", new_audit_title)
         print newly_created_audit
         util.waitForElementToBePresent(newly_created_audit)
         self.assertTrue(util.isElementPresent(newly_created_audit), "do not see the newly created audit " +new_audit_title )
         
         # 6. Click on it to open the 2nd tier info.  confirm there are 3 requests in the PBC Requests section. 
-        newly_created_audit_open_link  = element.audit_area_created_audit_open_link.replace("AUDIT_TITLE", new_audit_title)
+        newly_created_audit_open_link  = element.audit_area_by_title.replace("AUDIT_TITLE", new_audit_title)
         print newly_created_audit_open_link
         util.waitForElementToBePresent(newly_created_audit_open_link)
         self.assertTrue(util.isElementPresent(newly_created_audit_open_link), "do not see the newly created audit open link "  )

--- a/Audit/TestProgramAuditDocumentationRequest.py
+++ b/Audit/TestProgramAuditDocumentationRequest.py
@@ -53,14 +53,14 @@ class TestProgramAuditDocumentationRequest(WebDriverTestCase):
         
         # 2.  Choose Audit from Object page nav to bring up the Audit widget
         do.navigateToAuditSectionViaInnerNavSection("Audit")
-        newly_created_audit = element.audit_area_created_audit.replace("AUDIT_TITLE", "2014: program - Audit")
+        newly_created_audit = element.audit_area_by_title.replace("AUDIT_TITLE", "2014: program - Audit")
        
         print newly_created_audit
         util.waitForElementToBePresent(newly_created_audit)
         self.assertTrue(util.isElementPresent(newly_created_audit), "do not see the newly created audit " +"2014: program - Audit" )
         
         # 6. Click on it to open the 2nd tier info.  confirm there are 3 requests in the PBC Requests section. 
-        newly_created_audit_open_link  = element.audit_area_created_audit_open_link.replace("AUDIT_TITLE", "2014: program - Audit")
+        newly_created_audit_open_link  = element.audit_area_by_title.replace("AUDIT_TITLE", "2014: program - Audit")
         print newly_created_audit_open_link
         util.waitForElementToBePresent(newly_created_audit_open_link)
         self.assertTrue(util.isElementPresent(newly_created_audit_open_link), "do not see the newly created audit open link "  )
@@ -134,14 +134,14 @@ class TestProgramAuditDocumentationRequest(WebDriverTestCase):
         util.backBrowser()
         util.refreshPage()
         #waiting to audit to appear back
-        newly_created_audit = element.audit_area_created_audit.replace("AUDIT_TITLE", "2014: program - Audit")
-        #newly_created_audit = element.audit_area_created_audit.replace("AUDIT_TITLE", new_audit_title)
+        newly_created_audit = element.audit_area_by_title.replace("AUDIT_TITLE", "2014: program - Audit")
+        #newly_created_audit = element.audit_area_by_title.replace("AUDIT_TITLE", new_audit_title)
         print newly_created_audit
         util.waitForElementToBePresent(newly_created_audit)
         self.assertTrue(util.isElementPresent(newly_created_audit), "do not see the newly created audit 2014: program - Audit")
          
-        newly_created_audit_open_link  = element.audit_area_created_audit_open_link.replace("AUDIT_TITLE", "2014: program - Audit") 
-        #newly_created_audit_open_link  = element.audit_area_created_audit_open_link.replace("AUDIT_TITLE", new_audit_title)
+        newly_created_audit_open_link  = element.audit_area_by_title.replace("AUDIT_TITLE", "2014: program - Audit") 
+        #newly_created_audit_open_link  = element.audit_area_by_title.replace("AUDIT_TITLE", new_audit_title)
         print newly_created_audit_open_link
         util.waitForElementToBePresent(newly_created_audit_open_link)
         self.assertTrue(util.isElementPresent(newly_created_audit_open_link), "do not see the newly created audit open link "  )

--- a/Audit/TestProgramAuditInterviewRequest.py
+++ b/Audit/TestProgramAuditInterviewRequest.py
@@ -51,14 +51,14 @@ class TestProgramAuditInterviewRequest(WebDriverTestCase):
         
         # 2.  Choose Audit from Object page nav to bring up the Audit widget
         do.navigateToAuditSectionViaInnerNavSection("Audit")
-        newly_created_audit = element.audit_area_created_audit.replace("AUDIT_TITLE", "2014: program - Audit")
+        newly_created_audit = element.audit_area_by_title.replace("AUDIT_TITLE", "2014: program - Audit")
        
         print newly_created_audit
         util.waitForElementToBePresent(newly_created_audit)
         self.assertTrue(util.isElementPresent(newly_created_audit), "do not see the newly created audit " +"2014: program - Audit" )
         
         # 6. Click on it to open the 2nd tier info.  confirm there are 3 requests in the PBC Requests section. 
-        newly_created_audit_open_link  = element.audit_area_created_audit_open_link.replace("AUDIT_TITLE", "2014: program - Audit")
+        newly_created_audit_open_link  = element.audit_area_by_title.replace("AUDIT_TITLE", "2014: program - Audit")
         print newly_created_audit_open_link
         util.waitForElementToBePresent(newly_created_audit_open_link)
         self.assertTrue(util.isElementPresent(newly_created_audit_open_link), "do not see the newly created audit open link "  )

--- a/Audit/TestProgramAuditPopulationSampleRequest.py
+++ b/Audit/TestProgramAuditPopulationSampleRequest.py
@@ -49,14 +49,14 @@ class TestProgramAuditPopulationSampleRequest(WebDriverTestCase):
         
         # 2.  Choose Audit from Object page nav to bring up the Audit widget
         do.navigateToAuditSectionViaInnerNavSection("Audit")
-        newly_created_audit = element.audit_area_created_audit.replace("AUDIT_TITLE", "2014: program - Audit")
+        newly_created_audit = element.audit_area_by_title.replace("AUDIT_TITLE", "2014: program - Audit")
        
         print newly_created_audit
         util.waitForElementToBePresent(newly_created_audit)
         self.assertTrue(util.isElementPresent(newly_created_audit), "do not see the newly created audit " +"2014: program - Audit" )
         
         # 6. Click on it to open the 2nd tier info.  confirm there are 3 requests in the PBC Requests section. 
-        newly_created_audit_open_link  = element.audit_area_created_audit_open_link.replace("AUDIT_TITLE", "2014: program - Audit")
+        newly_created_audit_open_link  = element.audit_area_by_title.replace("AUDIT_TITLE", "2014: program - Audit")
         print newly_created_audit_open_link
         util.waitForElementToBePresent(newly_created_audit_open_link)
         self.assertTrue(util.isElementPresent(newly_created_audit_open_link), "do not see the newly created audit open link "  )

--- a/helperRecip/Elements.py
+++ b/helperRecip/Elements.py
@@ -10,7 +10,7 @@ class Elements(object):
         modal_window = '//div[@class="modal-body"]'
         audit_area_plus_audit_link = '//a[contains(@data-object-singular,"Audit")][contains(@class,"section-create")]'
         audit_area_create_audit_link = '//span[contains(@class,"section-expander")]//a[@data-object-singular="Audit"]'
-        audit_area_created_audit = '//li[@data-object-type="audit"]//div[@class="tree-title-area"][contains(.,"AUDIT_TITLE")]'
+        audit_area_by_title = '//li[@data-object-type="audit"][descendant::div[@class="tree-title-area"][contains(., "AUDIT_TITLE")]]'
         audit_edit = '//ancestor::li[@data-object-type="audit"]//i[@class="grcicon-edit"]/parent::a'
         audit_area_created_audit_open_link = '//li[@data-object-type="audit"]//a//div[@class="tree-title-area"][contains(.,"AUDIT_TITLE")]/parent::div/parent::div/parent::div/parent::a'
 
@@ -84,6 +84,7 @@ class Elements(object):
         chrome_login_prompt = '//form[contains(@action, "ChromeLoginPrompt")]'
         chrome_login_skip_button = chrome_login_prompt + """//input[@onclick="setFormAction('no')"]"""
 
+        first_link_within = '//a'
         flash_box = '//div[@class="flash"]'
         flash_box_type = flash_box + '//div[contains(@class, "alert-TYPE")]'
         flash_box_type_dismiss = flash_box_type + '//a[@class="close"]'

--- a/helperRecip/Helpers.py
+++ b/helperRecip/Helpers.py
@@ -778,7 +778,7 @@ class Helpers(unittest.TestCase):
         self.assertTrue(self.util.waitForElementToBePresent(active_section), "ERROR inside mapAObjectWidget(): no active section for "+ object)
         
     @log_time
-    def createAudit(self, audit_title):
+    def createAudit(self, program_name):
         #verify modal window
         self.util.waitForElementToBeVisible(self.element.modal_window)
         self.assertTrue(self.util.isElementPresent(self.element.modal_window), "can't see modal dialog window for create new object")
@@ -787,8 +787,9 @@ class Helpers(unittest.TestCase):
         self.util.waitForElementToBeVisible(self.element.object_title)
         self.assertTrue(self.util.isElementPresent(self.element.object_title), "can't access the input textfield")
 
-        #verification the title is correctly auto-populated
-        audit_auto_populated_title = self.util.getAnyAttribute(self.element.object_title,"value")
+        #set a unique title
+        audit_auto_populated_title = program_name + " Audit" + self.getTimeId()
+        self.util.inputTextIntoField(audit_auto_populated_title, self.element.object_title)
         self.util.clickOn(self.element.audit_modal_autogenerate_checkbox)
 
         #calculate the dates - Fill in start date (current date), Planned End Date (+2months), Planned Report date from(+1month from start), Planned report date to (Planned end date + 1 week)


### PR DESCRIPTION
Per [71040070](https://www.pivotaltracker.com/story/show/71040070).  Audit test was occasionally picking out a different audit than the one it had just created, which became more frequent with the db migration that enforced title uniqueness.  This adds a timestamp to enforce title uniqueness and ensure that new audits do not have a title that is a subset of another.
