### PR TITLE
update test script class name to start with 'Test'

### DIFF
--- a/SmokeTest/SuiteSmokeTest.py
+++ b/SmokeTest/SuiteSmokeTest.py
@@ -7,20 +7,20 @@ This are individual files from SmokeTestScript.  It's not 1-to-1 because some te
 together and you can't separate them.
 
 '''
+
 import unittest
 from SmokeTest.TestAllTabsIntegrity import TestAllTabsIntegrity
+from SmokeTest.TestCreateUpdateDeleteProgram import TestCreateUpdateDeleteProgram
 from SmokeTest.TestCreatePersonAuthorizationLogInOut import TestCreatePersonAuthorizationLogInOut
+from SmokeTest.TestCreateUpdateDeleteRegulation import TestCreateUpdateDeleteRegulation
+from SmokeTest.TestCreateUpdateDeleteSystem import TestCreateUpdateDeleteSystem
+from SmokeTest.TestEventLog import TestEventLog
+from SmokeTest.TestFourLevelsMapping import TestFourLevelsMapping
+from SmokeTest.TestImportExportPeople import TestImportExportPeople
+from SmokeTest.TestImportExportProcess import TestImportExportProcess
+from SmokeTest.TestImportExportSystem import TestImportExportSystem
 from SmokeTest.TestMapRegulationToSystem import TestMapRegulationToSystem
 from SmokeTest.TestMapSystemToPeople import TestMapSystemToPeople
 from SmokeTest.TestMapUnmapWorkflowToProgram import TestMapUnmapWorkflowToProgram
-from SmokeTest.TestCreatePersonAuthorizationLogInOut import TestCreatePersonAuthorizationLogInOut
-from SmokeTest.TestImportExportPeople import TestImportExportPeople
-from SmokeTest.TestImportExportSystem import TestImportExportSystem
-from SmokeTest.TestImportExportProcess import TestImportExportProcess
 #from SmokeTest.TestImportPeopleValidation import TestImportPeopleValidation
 #from SmokeTest.TestImportProcessesValidation import TestImportProcessesValidation
-from SmokeTest.TestEventLog import TestEventLog
-from SmokeTest.CreateUpdateDeleteProgram import CreateUpdateDeleteProgram
-from SmokeTest.CreateUpdateDeleteRegulation import CreateUpdateDeleteRegulation
-from SmokeTest.CreateUpdateDeleteSystem import CreateUpdateDeleteSystem
-from SmokeTest.TestFourLevelsMapping import TestFourLevelsMapping

--- a/SmokeTest/TestCreateANewUserInLHS.py
+++ b/SmokeTest/TestCreateANewUserInLHS.py
@@ -15,10 +15,10 @@ from helperRecip.WebdriverUtilities import WebdriverUtilities
 from helperRecip.testcase import *
 
 
-class CreateANewUserInLHS(WebDriverTestCase):
+class TestCreateANewUserInLHS(WebDriverTestCase):
        
     def testCreateANewUserInLHS(self):
-        self.testname="CreateANewUserInLHS"
+        self.testname="TestCreateANewUserInLHS"
         self.setup()
         util = WebdriverUtilities()
         util.setDriver(self.driver)

--- a/SmokeTest/TestCreateUpdateDeleteProgram.py
+++ b/SmokeTest/TestCreateUpdateDeleteProgram.py
@@ -13,10 +13,10 @@ from helperRecip.WebdriverUtilities import WebdriverUtilities
 from helperRecip.testcase import *
 
 
-class CreateUpdateDeleteSystem(WebDriverTestCase):
+class TestCreateUpdateDeleteProgram(WebDriverTestCase):
 
-    def testCreateUpdateDeleteSystem(self):
-        self.testname="CreateUpdateDeleteSystem"
+    def testCreateUpdateDeleteProgram(self):
+        self.testname="TestCreateUpdateDeleteProgram"
         self.setup()
         util = WebdriverUtilities()
         util.setDriver(self.driver)
@@ -27,16 +27,15 @@ class CreateUpdateDeleteSystem(WebDriverTestCase):
         myUtil = do.getUtils()
         do.login()
         
-        aEmail = "testrecip@gmail.com" #already exists in the database
-        
-        last_created_object_link = do.createObject("System")
+        last_created_object_link = do.createObject("Program")
         object_name = str(do.util.getTextFromXpathString(last_created_object_link)).strip()
-        do.navigateToObjectAndOpenObjectEditWindow("System", last_created_object_link)
-        do.populateObjectInEditWindow(object_name , grcobject.system_elements, grcobject.system_values, aEmail)
+        do.navigateToObjectAndOpenObjectEditWindow("Program", last_created_object_link)
+        do.populateObjectInEditWindow(object_name , grcobject.program_elements, grcobject.program_values)
         do.openObjectEditWindow()
         do.showHiddenValues()
-        do.verifyObjectValues(grcobject.system_elements, grcobject.system_values)
+        do.verifyObjectValues(grcobject.program_elements, grcobject.program_values)
         do.deleteObject()
 
 if __name__ == "__main__":
+    #import sys;sys.argv = ['', 'Test.testName']
     unittest.main()

--- a/SmokeTest/TestCreateUpdateDeleteRegulation.py
+++ b/SmokeTest/TestCreateUpdateDeleteRegulation.py
@@ -13,10 +13,10 @@ from helperRecip.WebdriverUtilities import WebdriverUtilities
 from helperRecip.testcase import *
 
 
-class CreateUpdateDeleteRegulation(WebDriverTestCase):
+class TestCreateUpdateDeleteRegulation(WebDriverTestCase):
 
     def testCreateUpdateDeleteRegulation(self):
-        self.testname="CreateUpdateDeleteRegulation"
+        self.testname="TestCreateUpdateDeleteRegulation"
         self.setup()
         util = WebdriverUtilities()
         util.setDriver(self.driver)

--- a/SmokeTest/TestCreateUpdateDeleteSystem.py
+++ b/SmokeTest/TestCreateUpdateDeleteSystem.py
@@ -13,10 +13,10 @@ from helperRecip.WebdriverUtilities import WebdriverUtilities
 from helperRecip.testcase import *
 
 
-class CreateUpdateDeleteProgram(WebDriverTestCase):
+class TestCreateUpdateDeleteSystem(WebDriverTestCase):
 
-    def testCreateUpdateDeleteProgram(self):
-        self.testname="CreateUpdateDeleteProgram"
+    def testCreateUpdateDeleteSystem(self):
+        self.testname="TestCreateUpdateDeleteSystem"
         self.setup()
         util = WebdriverUtilities()
         util.setDriver(self.driver)
@@ -27,15 +27,16 @@ class CreateUpdateDeleteProgram(WebDriverTestCase):
         myUtil = do.getUtils()
         do.login()
         
-        last_created_object_link = do.createObject("Program")
+        aEmail = "testrecip@gmail.com" #already exists in the database
+        
+        last_created_object_link = do.createObject("System")
         object_name = str(do.util.getTextFromXpathString(last_created_object_link)).strip()
-        do.navigateToObjectAndOpenObjectEditWindow("Program", last_created_object_link)
-        do.populateObjectInEditWindow(object_name , grcobject.program_elements, grcobject.program_values)
+        do.navigateToObjectAndOpenObjectEditWindow("System", last_created_object_link)
+        do.populateObjectInEditWindow(object_name , grcobject.system_elements, grcobject.system_values, aEmail)
         do.openObjectEditWindow()
         do.showHiddenValues()
-        do.verifyObjectValues(grcobject.program_elements, grcobject.program_values)
+        do.verifyObjectValues(grcobject.system_elements, grcobject.system_values)
         do.deleteObject()
 
 if __name__ == "__main__":
-    #import sys;sys.argv = ['', 'Test.testName']
     unittest.main()


### PR DESCRIPTION
test scripts can run in Eclipse but can't run from a terminal because the class name is not start with 'test' but function start with "test".  It seems like there is a requirement that the classname and first name to match for nosetests to pickup properly.
